### PR TITLE
chore(ci): add markdownlint for markdown formatting check

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -1,0 +1,23 @@
+name: Markdown Lint
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run linter
+        id: markdownlint
+        uses: docker://avtodev/markdown-lint:v1@sha256:6aeedc2f49138ce7a1cd0adffc1b1c0321b841dc2102408967d9301c031949ee
+        with:
+          config: .markdownlint.yaml
+          args: '**/*.md'

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,30 @@
+# Default state for all rules
+default: true
+
+# ul-style
+MD004: false
+
+# hard-tabs
+MD010: false
+
+# line-length
+MD013:
+  line_length: 100
+  strict: false
+
+# no-duplicate-header
+MD024:
+  siblings_only: true
+
+#single-title
+MD025: false
+
+# ol-prefix
+MD029:
+  style: ordered
+
+# no-inline-html
+MD033: false
+
+# fenced-code-language
+MD040: false


### PR DESCRIPTION
- Use docker-based markdownlint action
- Enforce soft line wrap at 100 characters
- Add .markdownlint.yaml config to allow flexibility (e.g. inline HTML, duplicate headers)