### PR TITLE
chore(ci): add markdownlint for markdown formatting check

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -11,6 +11,9 @@ MD010: false
 MD013:
   line_length: 100
   strict: false
+  code_blocks: false
+  tables: false
+  code_block_line_length: 80
 
 # no-duplicate-header
 MD024:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,8 +113,8 @@ git commit
 git push <YOUR_FORK> <YOUR_BRANCH_NAME>
 ```
 
-Open a pull request against the main `opentelemetry-go-compile-instrumentation` repo. Be sure to add the pull
-request ID to the entry you added to `CHANGELOG.md`.
+Open a pull request against the main `opentelemetry-go-compile-instrumentation` repo.
+Be sure to add the pull request ID to the entry you added to `CHANGELOG.md`.
 
 Avoid rebasing and force-pushing to your branch to facilitate reviewing the pull request.
 Rewriting Git history makes it difficult to keep track of iterations during code review.

--- a/README.md
+++ b/README.md
@@ -5,21 +5,27 @@
 > [!IMPORTANT]
 > This is a work in progress and not ready for production use. 🚨
 
-This project provides a tool to automatically instrument Go applications with [OpenTelemetry](https://opentelemetry.io/) at compile time. It modifies the Go build process to inject OpenTelemetry code into the application without requiring manual changes to the source code.
+This project provides a tool to automatically instrument Go applications with
+[OpenTelemetry](https://opentelemetry.io/) at compile time.
+
+It modifies the Go build process to inject OpenTelemetry code into the application without
+requiring manual changes to the source code.
 
 ## Getting Started
 
 1. Build the otel tool
-```bash
-$ git clone https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation.git
-$ cd opentelemetry-go-compile-instrumentation
-$ make build
-```
+
+    ```bash
+    git clone https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation.git
+    cd opentelemetry-go-compile-instrumentation
+    make build
+    ```
 
 2. Build the application with the tool and run it
-```bash
-$ make demo
-```
+
+    ```bash
+    make demo
+    ```
 
 ## Contributing
 

--- a/docs/api-design-and-project-structure.md
+++ b/docs/api-design-and-project-structure.md
@@ -5,25 +5,27 @@ The project structure is as follows:
 - `demo`: Demo Application
 - `instrumentation`: Instrumentation code for each plugin (e.g. http, rpc, db, messaging, network, ...)
 - `pkg`: Public API
-    - `inst-api`: Encapsulation of instrumentation (generating span, metrics, ...)
-    - `inst-api-semconv`: Encapsulation of OpenTelemetry SemConv
-        - `instrumenter`
-            - `http`
-            - `rpc`
-            - `db`
-            - `messaging`
-            - `network`
-            - ...
+  - `inst-api`: Encapsulation of instrumentation (generating span, metrics, ...)
+  - `inst-api-semconv`: Encapsulation of OpenTelemetry SemConv
+    - `instrumenter`
+      - `http`
+      - `rpc`
+      - `db`
+      - `messaging`
+      - `network`
+      - ...
 - `tool`: Compile-time instrumentation tool
   - `internal/setup`: Setup phase, it prepares the environment for future instrumentation phase
   - `internal/instrument`: Instrument phase, where the actual instrumentation happens
-  - `internal/rule`: The rule describes how to match the target function and which instrumentation to apply
+  - `internal/rule`: The rule describes how to match the target function
+  and which instrumentation to apply
 
 For Public API, we have some key abstractions as follows:
 
 1. `Instrumenter`: Unified entrance of instrumentation (generating span, metrics, ...)
 2. `Extractor`: Extracting attributes using multiple Getters according to [OpenTelemetry Semconv](https://opentelemetry.io/docs/specs/semconv/).
-3. `Getter`: Getting attributes from the REQUEST object(For example, HTTPRequest object that HTTP Server received).
+3. `Getter`: Getting attributes from the REQUEST object(For example,
+ HTTPRequest object that HTTP Server received).
 4. `AttrsShadower`: An extension for Extractor to customize the attributes extracted by the extractor.
 5. `OperationListener`: An hook for better extension(For example, aggregate the metrics).
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,7 +1,7 @@
 # Developing Details
 
-
 ## Project Structure
+
 See the [project structure](./api-design-and-project-structure.md).
 
 ## Error Handling

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -47,7 +47,6 @@ func Trampoline() {
 var Hook func()
 ```
 
-
 ## 2. Linkage via golinkname
 
 The `Hook` function is linked to the monitoring code using the `//go:linkname`
@@ -63,22 +62,24 @@ a custom toolchain.
 ## Phase 1: Setup Dependencies
 
 ### 1.1 Dependency Analysis
-The first step is to analyze the project's dependencies by collecting the list 
-of modules involved in the build. This is done using the `go build -n` command, 
+
+The first step is to analyze the project's dependencies by collecting the list
+of modules involved in the build. This is done using the `go build -n` command,
 which prints the build plan without executing it.
 
 ```command
-$ go build -n > build_plan.txt
+go build -n > build_plan.txt
 ```
 
-From the build_plan.txt file, the tool extracts all third-party module paths 
+From the build_plan.txt file, the tool extracts all third-party module paths
 (e.g., `github.com/go-redis/redis`, `github.com/gin-gonic/gin`).
 
 ## 1.2 Add Dependencies
+
 The hook configuration is specified by [ux-design.md](ux-design.md),
-which includes the `ImportPath` field where the target function resides. The tool 
+which includes the `ImportPath` field where the target function resides. The tool
 matches this `ImportPath` against the pre-collected third-party dependencies and
-generates a file (e.g., otel_import.go) to import the SDK and corresponding hook 
+generates a file (e.g., otel_import.go) to import the SDK and corresponding hook
 packages for matched dependency
 
 ```go
@@ -108,12 +109,11 @@ The build process can be integrated with custom toolchains in the following ways
 - Direct flag: `go build -toolexec=otel toolexec` (on-demand use; ideal for scripts/CI)
 
 All of these leverage the `-toolexec` flag, which allows users to specify a
-custom tool (e.g., otel) that intercepts compilation commands. The tool identifies 
+custom tool (e.g., otel) that intercepts compilation commands. The tool identifies
 the target function from the compilation commands and injects trampoline code
 into the AST of these functions. Since the hook dependency was already imported
 in Phase 1, the tool can link the target function to the hook code via `//go:linkname`
 without requiring any additional modifications.
-
 
 # Interface Design
 

--- a/docs/ux-design.md
+++ b/docs/ux-design.md
@@ -15,6 +15,7 @@ significant code change beyond adding simple, well-defined configuration that
 may be as simple as adding the relevant tool dependencies.
 
 The main value proposition is:
+
 - Very little effort is required for holistic instrumentation
 - Ability to instrument within third-party dependencies
 - Keeping the codebase completely de-coupled from instrumentation
@@ -36,6 +37,7 @@ is composed of the following personas:
 - System operators look to instrument applications without involving developers
 
 The tool may however also be relevant to the following personas:
+
 - Security personnel looking for maximal instrumentation coverage
 - Library developers looking to improve the instrumentation experience for their
   library
@@ -187,25 +189,24 @@ used directly to build, run, and test go applications directly:
 1. If the tool is installed as a Go `tool` dependency (`go1.24` and newer):
 
    ```console
-   $ go tool otel go build -o bin/app .
-   $ go tool otel go test -shuffle=on ./...
+   go tool otel go build -o bin/app .
+   go tool otel go test -shuffle=on ./...
    ```
 
 2. Installing `otel` in `$GOBIN`
 
    ```console
-   $ go install github.com/open-telemetry/opentelemetry-go-compile-instrumentation/cmd/otel
-   $ otel go build -o bin/app
-   $ otel go test -shuffle=on ./...
+   go install github.com/open-telemetry/opentelemetry-go-compile-instrumentation/cmd/otel
+   otel go build -o bin/app
+   otel go test -shuffle=on ./...
    ```
 
 3. Running `otel` with `go run`:
 
    ```console
-   $ go run github.com/open-telemetry/opentelemetry-go-compile-instrumentation/cmd/otel go build -o bin/app
-   $ go run github.com/open-telemetry/opentelemetry-go-compile-instrumentation/cmd/otel go test -shuffle=on ./...
+   go run github.com/open-telemetry/opentelemetry-go-compile-instrumentation/cmd/otel go build -o bin/app
+   go run github.com/open-telemetry/opentelemetry-go-compile-instrumentation/cmd/otel go test -shuffle=on ./...
    ```
-
 
 ### Ongoing Maintenance
 
@@ -267,6 +268,7 @@ standard Go packages that are part of a Go module and contain either (or both):
   next section);
 - a `otel.instrumentation.go` file that imports at least one valid
   instrumentation package:
+
   ```go
   //go:build tools
   package tools


### PR DESCRIPTION
- Use docker-based markdownlint action
- Enforce soft line wrap at 100 characters
- Add .markdownlint.yaml config to allow flexibility (e.g. inline HTML, duplicate headers)